### PR TITLE
refactor: read Neo4j password from environment

### DIFF
--- a/VideoGame_Turn.py
+++ b/VideoGame_Turn.py
@@ -1,8 +1,12 @@
+import os
 from neo4j import GraphDatabase
 
 # Connect to local Neo4j instance
 URI = "neo4j+s://54735458.databases.neo4j.io"
-AUTH = ("neo4j", "xubGBJZ3Kigpr_8keBHM-v2WwwvjLzeJntB-XQBFpSY")  # replace with your actual password
+PASSWORD = os.getenv("NEO4J_PASSWORD")
+if PASSWORD is None:
+    raise EnvironmentError("NEO4J_PASSWORD environment variable not set")
+AUTH = ("neo4j", PASSWORD)
 
 driver = GraphDatabase.driver(URI, auth=AUTH)
 


### PR DESCRIPTION
## Summary
- replace hard-coded Neo4j password with environment variable

## Testing
- `python -m py_compile VideoGame_Turn.py`
- `NEO4J_PASSWORD=fake python VideoGame_Turn.py` *(fails: ModuleNotFoundError: No module named 'neo4j')*

------
https://chatgpt.com/codex/tasks/task_e_68ab5c39681c832e9f013654f4dd1277