### PR TITLE
Add visualization and database dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "networkx>=3.0",
     "pandas>=2.0",
     "matplotlib>=3.0",
+    "solara>=1.0",
+    "neo4j>=5.0",
 ]
 
 [tool.poetry]
@@ -30,6 +32,8 @@ mesa = ">=2.2"
 networkx = ">=3.0"
 pandas = ">=2.0"
 matplotlib = ">=3.0"
+solara = ">=1.0"
+neo4j = ">=5.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ mesa>=2.2
 networkx>=3.0
 pandas>=2.0
 matplotlib>=3.0
+solara>=1.0
+neo4j>=5.0


### PR DESCRIPTION
## Summary
- add solara and neo4j to dependency lists

## Testing
- `pip install solara neo4j` *(fails: Could not find a version that satisfies the requirement solara)*
- `pytest`
- `python -m sim.viz --agents 1 --p_edge 0.1` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68ab66078ca4832e80a197f8707870e5