### PR TITLE
Add missing Altair dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "matplotlib>=3.0",
     "solara>=1.0",
     "neo4j>=5.0",
+    "altair>=5.0",
 ]
 
 [tool.poetry]
@@ -34,6 +35,7 @@ pandas = ">=2.0"
 matplotlib = ">=3.0"
 solara = ">=1.0"
 neo4j = ">=5.0"
+altair = ">=5.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas>=2.0
 matplotlib>=3.0
 solara>=1.0
 neo4j>=5.0
+altair>=5.0


### PR DESCRIPTION
## Summary
- Add Altair to project dependencies for visualization support
- Include Altair in requirements file

## Testing
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6a36a2b4832e88faae315c9cc1e7