### PR TITLE
Load Neo4j config from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEO4J_URI=neo4j+s://54735458.databases.neo4j.io
+NEO4J_PASSWORD=your_password_here

--- a/VideoGame_Turn.py
+++ b/VideoGame_Turn.py
@@ -1,11 +1,15 @@
 import os
 from neo4j import GraphDatabase
 
-# Connect to local Neo4j instance
-URI = "neo4j+s://54735458.databases.neo4j.io"
+# Connect to Neo4j instance using environment variables
+URI = os.getenv("NEO4J_URI")
+if URI is None:
+    raise EnvironmentError("NEO4J_URI environment variable not set")
+
 PASSWORD = os.getenv("NEO4J_PASSWORD")
 if PASSWORD is None:
     raise EnvironmentError("NEO4J_PASSWORD environment variable not set")
+
 AUTH = ("neo4j", PASSWORD)
 
 driver = GraphDatabase.driver(URI, auth=AUTH)


### PR DESCRIPTION
## Summary
- Load Neo4j URI from `NEO4J_URI` env var and keep password in `NEO4J_PASSWORD`
- Add `.env.example` to document required environment variables

## Testing
- `python -m py_compile VideoGame_Turn.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab6be5159c832e9a436c5a6419c960