### PR TITLE
Replace nonexistent mesa-visualization dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 
 A minimal, git-ready starter for a two-goods trade & information-flow simulation using [Mesa](https://mesa.readthedocs.io/) and NetworkX.
 
+**Note:** Mesa's visualization components rely on Solara, which currently supports Python versions up to 3.12.
+
 ## Quick start (pip + venv)
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -U pip
-pip install -r requirements.txt
+pip install -r requirements.txt  # installs Mesa with visualization extras
 python -m sim.run --steps 50 --agents 50 --p_edge 0.1
 ```
 
@@ -20,7 +22,7 @@ poetry run python -m sim.run --steps 50 --agents 50 --p_edge 0.1
 
 ## Run with visualization (optional)
 ```bash
-python -m sim.viz --agents 50 --p_edge 0.1
+python -m sim.viz --agents 50 --p_edge 0.1  # requires Python ≤3.12
 ```
 
 ## Project layout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,9 @@ authors = [{name="You"}]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "mesa>=2.2",
-    "mesa-visualization>=3.0",
+    "mesa[visualization]>=3.0",
     "networkx>=3.0",
     "pandas>=2.0",
-    "matplotlib>=3.0",
-    "solara>=1.0",
     "neo4j>=5.0",
     "altair>=5.0",
 ]
@@ -30,12 +27,9 @@ packages = [{ include = "sim", from = "src" }]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
-mesa = ">=2.2"
-mesa-visualization = ">=3.0"
+mesa = {version = ">=3.0", extras = ["visualization"]}
 networkx = ">=3.0"
 pandas = ">=2.0"
-matplotlib = ">=3.0"
-solara = ">=1.0"
 neo4j = ">=5.0"
 altair = ">=5.0"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
-mesa>=2.2
 mesa[visualization]>=3.0
 networkx>=3.0
 pandas>=2.0
-matplotlib>=3.0
-solara>=1.0
 neo4j>=5.0
 altair>=5.0


### PR DESCRIPTION
## Summary
- depend on `mesa[visualization]` instead of the non-existent `mesa-visualization`
- document Python ≤3.12 requirement for Solara-based visualization

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement neo4j>=5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6d692884832e81e220b8c9ed8961