### PR TITLE
Switch visualization to Solara

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A minimal, git-ready starter for a two-goods trade & information-flow simulation
 python3 -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -U pip
-pip install -r requirements.txt  # installs Mesa with visualization extras
+pip install -r requirements.txt  # installs Mesa with Solara extras
 python -m sim.run --steps 50 --agents 50 --p_edge 0.1
 ```
 
@@ -22,7 +22,7 @@ poetry run python -m sim.run --steps 50 --agents 50 --p_edge 0.1
 
 ## Run with visualization (optional)
 ```bash
-python -m sim.viz --agents 50 --p_edge 0.1  # requires Python ≤3.12
+python -m sim.viz --agents 50 --p_edge 0.1  # launches Solara viz (Python ≤3.12)
 ```
 
 ## Project layout
@@ -40,5 +40,5 @@ pyproject.toml  (optional Poetry)
 
 ## Notes
 - `run.py` runs a headless simulation and prints a small summary.
-- `viz.py` launches Mesa's web server with a simple network visualization, handy for debugging.
+- `viz.py` launches a Solara-based network visualization, handy for debugging.
 - This is intentionally small; extend agent rules, add price formation, and write events to Parquet/DuckDB as you go.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ authors = [{name="You"}]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mesa[visualization]>=3.0",
+    "mesa>=3.0",
+    "solara>=1.30",
     "networkx>=3.0",
     "pandas>=2.0",
     "neo4j>=5.0",
@@ -27,7 +28,8 @@ packages = [{ include = "sim", from = "src" }]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
-mesa = {version = ">=3.0", extras = ["visualization"]}
+mesa = ">=3.0"
+solara = ">=1.30"
 networkx = ">=3.0"
 pandas = ">=2.0"
 neo4j = ">=5.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-mesa[visualization]>=3.0
+mesa>=3.0
+solara>=1.30
 networkx>=3.0
 pandas>=2.0
 neo4j>=5.0


### PR DESCRIPTION
## Summary
- replace legacy NetworkModule/ChartModule visualization with SolaraViz component
- document Solara run instructions and update dependencies

## Testing
- `python -m py_compile sim/viz.py`
- `python -m sim.run --steps 5 --agents 10 --p_edge 0.1` *(fails: ModuleNotFoundError: No module named 'mesa.time')*
- `python -m sim.viz --help` *(fails: ModuleNotFoundError: No module named 'solara')*


------
https://chatgpt.com/codex/tasks/task_e_68ab7317ec10832e94fc141d60fc9e7a