### PR TITLE
Use Solara AppScript for viz server

### DIFF
--- a/sim/viz.py
+++ b/sim/viz.py
@@ -4,6 +4,7 @@ import argparse
 
 import solara as sl
 from mesa.visualization import SolaraViz
+from solara.server import app as solara_app
 
 from sim.model import TradeModel
 
@@ -38,5 +39,5 @@ if __name__ == "__main__":
     parser.add_argument("--p_edge", type=float, default=0.1, help="Edge probability")
     args = parser.parse_args()
 
-    sl.run(build_app(args.agents, args.p_edge))
+    solara_app.AppScript(build_app(args.agents, args.p_edge)).run()
 


### PR DESCRIPTION
## Summary
- Delegate Solara visualization runner to `solara.server.app.AppScript` instead of `solara.run`

## Testing
- `python sim/viz.py --agents 5 --p_edge 0.2` *(fails: No module named 'matplotlib')*


------
https://chatgpt.com/codex/tasks/task_e_68acb09a67ac832ea6ea1fc6a83e0239