### PR TITLE
Ensure sim modules import correctly in viz

### DIFF
--- a/sim/viz.py
+++ b/sim/viz.py
@@ -6,6 +6,8 @@ import solara as sl
 from mesa.visualization import SolaraViz
 from solara.server import app as solara_app
 
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 from sim.model import TradeModel
 
 


### PR DESCRIPTION
## Summary
- Add sys path adjustment in `sim/viz.py` so the `sim` package can be imported when running the file directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb3e812b8832e86d2eee590e546e2